### PR TITLE
Disable TestFlight during simulations

### DIFF
--- a/Source/LaunchGUI.cs
+++ b/Source/LaunchGUI.cs
@@ -1648,6 +1648,14 @@ namespace KRASH
             GUILayout.EndHorizontal();
             GUILayout.Space(10);
 
+            if (KRASH.testFlightLoaded)
+            {
+                GUILayout.BeginHorizontal();
+                KRASHShelter.instance.disableTestFlightForSim = GUILayout.Toggle(KRASHShelter.instance.disableTestFlightForSim, "Disable TestFlight");
+                GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+            }
+
             if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
             {
 


### PR DESCRIPTION
This isn't done yet; I got something working, but I'm not sure how to make it work when TF isn't actually around. What is the proper way of doing such a thing?

It's also super hacky, since it meddles with TestFlightCore directly, but at least it seems to work?

Took a guess as to where the TestFlightCore dll would be on your system. No idea if it's right.

No idea whether the null checks are actually necessary, either.

My apologies for the rather poor PR quality...