### PR TITLE
Added option to ignore pad limits when simulating

### DIFF
--- a/Source/Configuration.cs
+++ b/Source/Configuration.cs
@@ -54,6 +54,8 @@ namespace KRASH
 
 		public bool		ContinueIfNoCash{ get; set; }
 
+		public bool     ObeyPadLimits { get; set; }
+
 		public bool		TerminateAtSoiWithoutData{ get; set; }
 		public bool		TerminateAtLandWithoutData{ get; set; }
 		public bool		TerminateAtAtmoWithoutData{ get; set; }
@@ -96,6 +98,7 @@ namespace KRASH
 			TerminateAtAtmoWithoutData = false;
 
 			ContinueIfNoCash = false;
+			ObeyPadLimits = false;
 			DefaultMaxAllowableSimCost = 0.0F;
 			DefaultSimTime = 5;
 
@@ -147,6 +150,7 @@ namespace KRASH
 			Log.Info ("TerminateAtSoiWithoutData: " + TerminateAtSoiWithoutData.ToString ());
 			Log.Info ("TerminateAtAtmoWithoutData: " + TerminateAtAtmoWithoutData.ToString ());
 			Log.Info ("ContinueIfNoCash: " + ContinueIfNoCash.ToString());
+			Log.Info ("ObeyPadLimits: " + ObeyPadLimits.ToString());
 			Log.Info ("MaxAllowableSimCost: " + MaxAllowableSimCost.ToString());
 			Log.Info ("DefaultSimTime: " + DefaultSimTime.ToString ());
 		}
@@ -173,6 +177,7 @@ namespace KRASH
 			TerminateAtAtmoWithoutData = bool.Parse(SafeLoad(node.GetValue("TerminateAtAtmoWithoutData"), TerminateAtAtmoWithoutData));
 
 			ContinueIfNoCash = bool.Parse (SafeLoad (node.GetValue ("ContinueIfNoCash"), ContinueIfNoCash));
+			ObeyPadLimits = bool.Parse (SafeLoad (node.GetValue ("ObeyPadLimits"), ObeyPadLimits));
 			DefaultMaxAllowableSimCost = float.Parse (SafeLoad (node.GetValue ("DefaultMaxAllowableSimCost"), DefaultMaxAllowableSimCost));
 			DefaultSimTime = int.Parse (SafeLoad (node.GetValue ("DefaultSimTime"), DefaultSimTime));
 
@@ -292,6 +297,7 @@ namespace KRASH
                     cfgNode.SetValue("TerminateAtLandWithoutData", TerminateAtLandWithoutData.ToString(), true);
                     cfgNode.SetValue("TerminateAtAtmoWithoutData", TerminateAtAtmoWithoutData.ToString(), true);
                     cfgNode.SetValue("ContinueIfNoCash", ContinueIfNoCash.ToString(), true);
+                    cfgNode.SetValue("ObeyPadLimits", ObeyPadLimits.ToString(), true);
                     cfgNode.SetValue("DefaultMaxAllowableSimCost", DefaultMaxAllowableSimCost.ToString(), true);
                     cfgNode.SetValue("DefaultSimTime", DefaultSimTime.ToString(), true);
                 }

--- a/Source/KRASH.cfg
+++ b/Source/KRASH.cfg
@@ -50,6 +50,7 @@ KRASH
 	// fairly self-explanatory
 
 	ContinueIfNoCash = true
+	ObeyPadLimits = false
 
 	// The following settings will terminate the simulation if the specified situation occurs:
 	// TerminateAtSoiWithoutData: Upon entering an SOI without any science data from either in orbit or landed

--- a/Source/KRASH.cs
+++ b/Source/KRASH.cs
@@ -383,6 +383,7 @@ namespace KRASH
 				Game newGame = GamePersistence.LoadGame ("KRASHRevert", HighLogic.SaveFolder, true, false);
 				GamePersistence.SaveGame (newGame, "persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
 				System.IO.File.Delete (KSPUtil.ApplicationRootPath + "saves/" + HighLogic.SaveFolder + "/" + "KRASHRevert.sfs");
+				System.IO.File.Delete (KSPUtil.ApplicationRootPath + "saves/" + HighLogic.SaveFolder + "/Ships/krash_temp.craft");
 
 
 


### PR DESCRIPTION
Fixes #35.

Adds an option to allow launching any size, weight, or part count craft for simulation.