### PR TITLE
Change teleport to use FlightGlobals.SetShipOrbit

### DIFF
--- a/Source/View/OrbitEditor.cs
+++ b/Source/View/OrbitEditor.cs
@@ -88,7 +88,7 @@ namespace KRASH.Hyperedit
 			var vessel = orbit.vessel;
 
 			if (vessel != null)
-				vessel.SetOrbit(newOrbit);
+				SetOrbit(vessel, newOrbit);
 			else
 				HardsetOrbit(orbit, newOrbit);
 		}
@@ -110,7 +110,8 @@ namespace KRASH.Hyperedit
 				return;
 			}
 
-			vessel.PrepVesselTeleport();
+			FlightGlobals.fetch.SetShipOrbit(newOrbit.referenceBody.flightGlobalsIndex, newOrbit.eccentricity, newOrbit.semiMajorAxis, newOrbit.inclination, newOrbit.LAN, newOrbit.meanAnomalyAtEpoch, newOrbit.argumentOfPeriapsis, newOrbit.ObT);
+			FloatingOrigin.ResetTerrainShaderOffset();
 
 			try
 			{
@@ -119,27 +120,6 @@ namespace KRASH.Hyperedit
 			catch (NullReferenceException)
 			{
 				Log.Info("OrbitPhysicsManager.HoldVesselUnpack threw NullReferenceException");
-			}
-
-			var allVessels = FlightGlobals.fetch == null ? (IEnumerable<Vessel>)new[] { vessel } : FlightGlobals.Vessels;
-			foreach (var v in allVessels.Where(v => v.packed == false))
-				v.GoOnRails();
-
-			var oldBody = vessel.orbitDriver.orbit.referenceBody;
-			Log.Info ("oldBody: " + oldBody.ToString ());
-			HardsetOrbit(vessel.orbitDriver, newOrbit);
-
-			vessel.orbitDriver.pos = vessel.orbit.pos.xzy;
-			vessel.orbitDriver.vel = vessel.orbit.vel;
-
-			var newBody = vessel.orbitDriver.orbit.referenceBody;
-			Log.Info ("newBody: " + newBody.ToString ());
-
-
-			if (newBody != oldBody)
-			{
-				var evnt = new GameEvents.HostedFromToAction<Vessel, CelestialBody>(vessel, oldBody, newBody);
-				GameEvents.onVesselSOIChanged.Fire(evnt);
 			}
 		}
 


### PR DESCRIPTION
This makes use of the teleportation functionality of SetShipOrbit instead of fudging it with random teleportation and such. This should fix  #15 and #26, and is a direct copy of edits @JonnyOThan did, found here: https://github.com/JonnyOThan/KRASH/commit/a627c3e8fb84649ee359eedd4c96ad5067c135db